### PR TITLE
Accept time_reg time input format as HH:MM

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,6 +22,9 @@ application.register("form", FormController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import InputController from "./input_controller"
+application.register("input", InputController)
+
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 

--- a/app/javascript/controllers/input_controller.js
+++ b/app/javascript/controllers/input_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="input"
+export default class extends Controller {
+  static targets = ["clone"];
+  connect() {
+  }
+
+  cloneValue(e) {
+    const eventTargetValue = e.target.value;
+    this.cloneTarget.value = this.stringToTime(eventTargetValue);
+  }
+
+  stringToTime(inputString) {
+    // Only allow numbers and colon
+    if (!/^[0-9:]+$/.test(inputString)) return NaN;
+
+    const [hours, minutes] = inputString.split(":").map(str => parseInt(str) || 0);
+
+    return (hours * 60) + (minutes || 0);
+  }
+}

--- a/app/views/time_regs/_new.html.erb
+++ b/app/views/time_regs/_new.html.erb
@@ -28,12 +28,13 @@
           <%= form.text_area :notes, class: 'w-full rounded-md p-2 border border-gray-300 focus:ring-1 focus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white' %>
         </div>
 
-        <div class="mb-4">
-          <%= form.label :minutes, class: 'block text-gray-700 text-sm font-bold mb-2' %>
+        <div class="mb-4" data-controller="input">
+          <%= form.label :minutes, "Time", class: 'block text-gray-700 text-sm font-bold mb-2' %>
           <% @time_reg.errors.full_messages_for(:minutes).each do |message| %>
             <div class="text-red-600 italic text-xs mt-1"><%= message %></div>
           <% end %>
-          <%= form.number_field :minutes, value: 0, class: 'w-full rounded-md p-2 border border-gray-300 focus:ring-1 focus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white' %>
+          <%= form.hidden_field :minutes, data: { "input-target": "clone" } %>
+          <%= form.text_field :minutes_string, placeholder: "0:00", data: { action: "input#cloneValue" }, class: 'text-end w-full rounded-md p-2 border border-gray-300 focus:ring-1 focus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white' %>
         </div>
 
          <div class="mb-4">


### PR DESCRIPTION
Updated TimeReg from to accept time in format HH:MM.
Added stimulus controller to convert format on the frontend.
Added hidden field in form.

![image](https://github.com/rubynor/reap/assets/29040689/a5966b53-6e5c-490a-9374-bc0166153c88)

