### PR TITLE
start time reg from create time reg modal when time is not provided

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,9 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "rails-controller-testing"
 end
 
 gem "sentry-ruby"
 gem "sentry-rails"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,10 @@ GEM
       activesupport (= 7.0.4.3)
       bundler (>= 1.15.0)
       railties (= 7.0.4.3)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -304,6 +308,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.2)
+  rails-controller-testing
   redis (~> 4.0)
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/controllers/time_regs_controller.rb
+++ b/app/controllers/time_regs_controller.rb
@@ -9,18 +9,14 @@ class TimeRegsController < ApplicationController
   def index
     @chosen_date = params.has_key?(:date) ? Date.parse(params[:date]) : Date.today
 
-    @time_regs = current_user.time_regs.where("date(date_worked) = ?", @chosen_date).includes(:project,
-                                                                                              :assigned_task).order(created_at: :desc)
+    @time_regs_week = current_user.time_regs.between_dates(@chosen_date.beginning_of_week, @chosen_date.end_of_week)
+
+    @time_regs = @time_regs_week.on_date(@chosen_date)
     @total_minutes_day = @time_regs.sum(:minutes)
     @minutes_by_day = minutes_by_day_of_week(@chosen_date, current_user)
     @projects = current_user.projects
     @time_reg = TimeReg.new(date_worked: @chosen_date)
 
-    # calculate the start and end date of the week of @chosen_date
-    start_date = @chosen_date.beginning_of_week
-    end_date = @chosen_date.end_of_week
-
-    @time_regs_week = current_user.time_regs.where("date(date_worked) BETWEEN ? AND ?", start_date, end_date)
     @total_minutes_week = @time_regs_week.sum(:minutes)
   end
 

--- a/app/controllers/time_regs_controller.rb
+++ b/app/controllers/time_regs_controller.rb
@@ -36,7 +36,7 @@ class TimeRegsController < ApplicationController
       @time_reg = TimeReg.new(time_reg_params.except(:project_id))
     end
 
-    @time_reg.active = @time_reg.minutes.nil? # start as active?
+    @time_reg.active = @time_reg.minutes.zero? # start as active?
     @time_reg.updated = Time.now
 
     if @time_reg.save

--- a/app/javascript/controllers/input_controller.js
+++ b/app/javascript/controllers/input_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
 
   handleSubmitButtonValue(inputValue) {
     if(this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.value = !!inputValue ? this.activeTextValue : this.inactiveTextValue;
+      this.submitButtonTarget.value = (!!inputValue && inputValue !== "0") ? this.activeTextValue : this.inactiveTextValue;
     }
   }
 }

--- a/app/javascript/controllers/input_controller.js
+++ b/app/javascript/controllers/input_controller.js
@@ -2,13 +2,21 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="input"
 export default class extends Controller {
-  static targets = ["clone"];
+  static targets = ["clone", "submitButton"];
+
+  static values = {
+    activeText: { type: String, default: '' },
+    inactiveText: { type: String, default: '' },
+  };
+
   connect() {
+    this.handleSubmitButtonValue(this.cloneTarget.value);
   }
 
   cloneValue(e) {
     const eventTargetValue = e.target.value;
     this.cloneTarget.value = this.stringToTime(eventTargetValue);
+    this.handleSubmitButtonValue(eventTargetValue);
   }
 
   stringToTime(inputString) {
@@ -18,5 +26,11 @@ export default class extends Controller {
     const [hours, minutes] = inputString.split(":").map(str => parseInt(str) || 0);
 
     return (hours * 60) + (minutes || 0);
+  }
+
+  handleSubmitButtonValue(inputValue) {
+    if(this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.value = !!inputValue ? this.activeTextValue : this.inactiveTextValue;
+    }
   }
 }

--- a/app/models/time_reg.rb
+++ b/app/models/time_reg.rb
@@ -1,4 +1,8 @@
 class TimeReg < ApplicationRecord
+  MINUTES_IN_A_DAY = 1.day.in_minutes.to_i
+
+  before_validation :set_default_minutes
+
   validates :notes, format: { without: /\r|\n/, message: "Line breaks are not allowed" }
 
   belongs_to :membership
@@ -25,4 +29,8 @@ class TimeReg < ApplicationRecord
         task: { id: task_ids },
       )
   }
+
+  def set_default_minutes
+    self.minutes ||= 0
+  end
 end

--- a/app/models/time_reg.rb
+++ b/app/models/time_reg.rb
@@ -1,8 +1,6 @@
 class TimeReg < ApplicationRecord
   MINUTES_IN_A_DAY = 1.day.in_minutes.to_i
 
-  before_validation :set_default_minutes
-
   validates :notes, format: { without: /\r|\n/, message: "Line breaks are not allowed" }
 
   belongs_to :membership
@@ -37,8 +35,4 @@ class TimeReg < ApplicationRecord
   scope :between_dates, ->(start_date, end_date) {
     where("date(date_worked) BETWEEN ? AND ?", start_date, end_date)
   }
-
-  def set_default_minutes
-    self.minutes ||= 0
-  end
 end

--- a/app/models/time_reg.rb
+++ b/app/models/time_reg.rb
@@ -30,6 +30,14 @@ class TimeReg < ApplicationRecord
       )
   }
 
+  scope :on_date, ->(given_date) {
+    where("date(date_worked) = ?", given_date).includes(:project, :assigned_task).order(created_at: :desc)
+  }
+
+  scope :between_dates, ->(start_date, end_date) {
+    where("date(date_worked) BETWEEN ? AND ?", start_date, end_date)
+  }
+
   def set_default_minutes
     self.minutes ||= 0
   end

--- a/app/views/time_regs/_new.html.erb
+++ b/app/views/time_regs/_new.html.erb
@@ -40,7 +40,7 @@
         %>
       </div>
 
-      <div class="mb-4" data-controller="input">
+      <%= content_tag :div, data: { controller: "input", "input-active_text_value": "Create Time reg", "input-inactive_text_value": "Start timer" } do %>
         <%= form.label :minutes, "Time", class: 'block text-gray-700 text-sm font-bold mb-2' %>
         <% time_reg.errors.full_messages_for(:minutes).each do |message| %>
           <div class="text-red-600 italic text-xs mt-1" data-refresh-minutes-target="output"><%= message %></div>
@@ -51,18 +51,18 @@
           class: 'text-end w-full rounded-md p-2 border border-gray-300 focus:ring-1 
           ocus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white' 
         %>
-      </div>
+        <%= form.hidden_field :date_worked %>
 
-      <%= form.hidden_field :date_worked %>
-
-      <div class="flex justify-center mt-8 px-4">
+        <div class="flex justify-center mt-8 px-4">
         <span class="rounded bg-seaGreen p-2 m-2 shadow text-white hover:bg-seaGreenDark">
-          <%= form.submit class: '' %>
+          <%= form.submit class: '', data: { input_target: "submitButton" } %>
         </span>
-        <div data-action="click->modal#toggle" class="cursor-pointer rounded bg-tastyWhiteLite p-2 m-2 hover:bg-red-100 shadow">
-          Cancel
+          <div data-action="click->modal#toggle" class="cursor-pointer rounded bg-tastyWhiteLite p-2 m-2 hover:bg-red-100 shadow">
+            Cancel
+          </div>
         </div>
-      </div>
+      <% end %>
+
     <% end %>
   </div>
 </div>

--- a/app/views/time_regs/_new.html.erb
+++ b/app/views/time_regs/_new.html.erb
@@ -46,7 +46,7 @@
           <div class="text-red-600 italic text-xs mt-1" data-refresh-minutes-target="output"><%= message %></div>
         <% end %>
         <%= form.hidden_field :minutes, data: { "input-target": "clone" } %>
-        <%= form.text_field :minutes_string, placeholder: "0:00", autocomplete: "off", 
+        <%= form.text_field :minutes_string, placeholder: "0:00", type: "time", autocomplete: "off",
           data: { action: "input#cloneValue" }, value: convert_time_int(time_reg.minutes), 
           class: 'text-end w-full rounded-md p-2 border border-gray-300 focus:ring-1 
           ocus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white' 

--- a/db/migrate/20240318161808_add_default_value_to_time_regs_minutes.rb
+++ b/db/migrate/20240318161808_add_default_value_to_time_regs_minutes.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToTimeRegsMinutes < ActiveRecord::Migration[7.0]
+  def up
+    change_column :time_regs, :minutes, :integer, null: false, default: 0
+  end
+
+  def down
+    change_column :time_regs, :minutes, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_04_143621) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_18_161808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_04_143621) do
 
   create_table "time_regs", force: :cascade do |t|
     t.text "notes"
-    t.integer "minutes"
+    t.integer "minutes", default: 0, null: false
     t.bigint "membership_id", null: false
     t.bigint "assigned_task_id", null: false
     t.datetime "created_at", null: false

--- a/test/controllers/time_regs_controller_test.rb
+++ b/test/controllers/time_regs_controller_test.rb
@@ -1,7 +1,61 @@
 require "test_helper"
 
-class TimeRegsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+class TimeRegsControllerTest < ActionController::TestCase
+  setup do
+    @user = users(:joe)
+    @current_date = Date.today
+    @time_reg = @user.time_regs.first
+
+    sign_in @user
+  end
+
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_equal @current_date, assigns(:chosen_date)
+    assert_equal @user.time_regs.on_date(@current_date), assigns(:time_regs)
+    assert_equal @user.time_regs.between_dates(@current_date.beginning_of_week, @current_date.end_of_week), assigns(:time_regs_week)
+  end
+
+  test "should toggle_active time_reg" do
+    assert_not @time_reg.active
+
+    patch :toggle_active, params: { time_reg_id: @time_reg.id }
+    assert_redirected_to time_regs_path
+    assert @time_reg.reload.active
+  end
+
+  test "should destroy time_reg" do
+    assert_difference('TimeReg.count', -1) do
+      delete :destroy , params: { id: @time_reg.id }
+    end
+
+    assert_redirected_to root_path(date: @time_reg.date_worked)
+  end
+
+  test "should record time_reg when valid" do
+    assert_difference('TimeReg.count') do
+      post :create, params: { time_reg: { date_worked: @current_date, minutes: 60, project_id: @user.projects.first.id, assigned_task_id: assigned_task(:task_1) } }
+    end
+
+    assert_redirected_to root_path(date: @current_date)
+    assert_not TimeReg.last.active
+  end
+
+  test "should record time_reg when valid and start timer when minutes where not provided" do
+    assert_difference('TimeReg.count') do
+      post :create, params: { time_reg: { date_worked: @current_date, project_id: @user.projects.first.id, assigned_task_id: assigned_task(:task_2) } }
+    end
+
+    assert_redirected_to root_path(date: @current_date)
+    assert TimeReg.last.active
+  end
+
+  test "should not record time_reg when invalid" do
+    assert_no_difference('TimeReg.count') do
+      post :create, params: { time_reg: { date_worked: @current_date, minutes: 0, project_id: nil, assigned_task_id: nil } }
+    end
+
+    assert_response :unprocessable_entity
+  end
 end

--- a/test/fixtures/time_regs.yml
+++ b/test/fixtures/time_regs.yml
@@ -30,3 +30,9 @@ time_reg_4:
   date_worked: <%= Date.today - 3 %>
   membership: e_corp_ron
   <<: *DEFAULTS
+
+time_reg_5:
+  assigned_task: task_1
+  date_worked: <%= Date.today - 1 %>
+  membership: e_corp_joe
+  <<: *DEFAULTS

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "rails-controller-testing"
 
 class ActiveSupport::TestCase
+  include Devise::Test::ControllerHelpers
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
 


### PR DESCRIPTION
### What this PR is adding

Ensuring timer is started whenever a newly created time reg does not provide `minutes` worked.

Some specs on `time_regs_controller` and minor changed to both `index` and `toggle_active` method