### PR TITLE
Fix conditionally creating projects report fixtures

### DIFF
--- a/test/fixtures/project_reports.yml
+++ b/test/fixtures/project_reports.yml
@@ -1,10 +1,11 @@
 <% Client.all.each_with_index do |client, index| %>
-project_report_<%= index %>:
-  timeframe: "allTime"
-  client_id: <%= client.id %>
-  project_id: <%= client.projects.first.id %>
-  task_ids: <%= client.projects.first.task_ids %>
-  member_ids: <%= User.ids %>
-  group_by: "date"
+  <% if client.projects.any? %>
+    project_report_<%= index %>:
+      timeframe: "allTime"
+      client_id: <%= client.id %>
+      project_id: <%= client.projects.first.id %>
+      task_ids: <%= client.projects.first&.task_ids %>
+      member_ids: <%= User.ids %>
+      group_by: "date"
+  <% end %>
 <% end %>
-


### PR DESCRIPTION
### What this PR is adding

We're facing a bug when fixtures are trying to be loaded `rake db:fixtures:load`

The change within this PR is checking for `client.projects` before creating `project_reports` for them.

By specifying association names instead of foreign keys for dependencies and ensurign these associations exists, Rails will resolve the associations based on the names regardless of alphabetical order

Apart from this i would like to propose to move away from fixtures and think about using https://github.com/thoughtbot/factory_bot or  https://fabricationgem.org/