### PR TITLE
remain at the same date when starting and stopping timer

### DIFF
--- a/app/controllers/time_regs_controller.rb
+++ b/app/controllers/time_regs_controller.rb
@@ -1,6 +1,6 @@
 class TimeRegsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_time_reg, only: [:toggle_active]
+  before_action :set_time_reg, only: [ :toggle_active ]
 
   require "activerecord-import/base"
   require "csv"
@@ -154,14 +154,14 @@ class TimeRegsController < ApplicationController
   def update_time_reg(current_status:)
     if current_status
       worked_minutes = (Time.now.to_i - @time_reg.updated.to_i) / 60
-      @time_reg.minutes = [@time_reg.minutes + worked_minutes, TimeReg::MINUTES_IN_A_DAY].min
+      @time_reg.minutes = [ @time_reg.minutes + worked_minutes, TimeReg::MINUTES_IN_A_DAY ].min
     else
       @time_reg.updated = Time.now
     end
 
     @time_reg.active = !current_status
 
-    redirect_to time_regs_path, notice: "Timer has been toggled #{current_status ? "off": "on"}" if @time_reg.save
+    redirect_to root_path(date: @time_reg.date_worked), notice: "Timer has been toggled #{current_status ? "off": "on"}" if @time_reg.save
   end
 
   def set_time_reg


### PR DESCRIPTION
When you start and stop the timer, you would before be sent to the current day.
Now when you start or stop the timer, you will remain at the same page. Similarly to when you edit or remove a task.

![image](https://github.com/rubynor/reap/assets/124353659/4fc83445-f6fe-428e-aafb-9dd2bc818c93)

![image](https://github.com/rubynor/reap/assets/124353659/8a63a763-4260-4c84-9d17-abf11e12ceb1)
