### PR TITLE
Make week overview more narrow

### DIFF
--- a/app/views/time_regs/index.html.erb
+++ b/app/views/time_regs/index.html.erb
@@ -1,6 +1,6 @@
 <% t = Time.new %>
 
-<div class="flex flex-row self-center m-auto w-full 2xl:w-3/4 ">
+<div class="flex flex-row self-center m-auto w-full max-w-[75rem]">
   <div class=" justify-items-center max-[800px]:hidden mt-[5vh]">
     <div class="content-center self-center justify-items-center ">
 


### PR DESCRIPTION
**Before:**
![Screenshot from 2024-03-21 10-06-55](https://github.com/rubynor/reap/assets/124353659/76664219-65c5-45d6-8898-8ab4c60d5d65)


**After:**

![Screenshot from 2024-03-21 09-54-48](https://github.com/rubynor/reap/assets/124353659/c2482282-6160-49fd-a56b-b21077d0d982)


I made the Overview smaller in with, making it more similar to what harvest have.