### PR TITLE
Adjust track time button

### DIFF
--- a/app/views/time_regs/index.html.erb
+++ b/app/views/time_regs/index.html.erb
@@ -1,7 +1,7 @@
 <% t = Time.new %>
 
 <div class="flex flex-row self-center m-auto w-full 2xl:w-3/4 ">
-  <div class=" justify-items-center max-[800px]:hidden mt-[5vh]">
+  <div class=" justify-items-center max-[800px]:hidden mt-[3vh]">
     <div class="content-center self-center justify-items-center ">
 
       <div class="flex flex-col self-center ">


### PR DESCRIPTION
A while ago the button was placed upwards.
Something happened and it was set lower than what it was supposed to.

**Before:**
![image](https://github.com/rubynor/reap/assets/124353659/e1d73623-56dc-4d69-a2b6-a9ac5461cde9)


**After:**

![image](https://github.com/rubynor/reap/assets/124353659/8a8a05ce-1f96-4c85-b177-9c56fb871473)


I fixed an issue where the button is close to tasks.