### PR TITLE
Fixing datepicker updating datetime

### DIFF
--- a/app/javascript/controllers/custom_calendar_controller.js
+++ b/app/javascript/controllers/custom_calendar_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-
-export default class extends Controller {
-    setValue(value) {
-        this.element.value = value;
-
-    //     trying to mimic phlex ui input controller that is passed as an outlet;
-    }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -55,7 +55,4 @@ application.register("custom-dialog", DialogController);
 import SnackbarController from "./snackbar_controller";
 application.register("snackbar", SnackbarController);
 
-import CustomCalendarController from "./custom_calendar_controller";
-application.register("custom-calendar", CustomCalendarController);
-
 // TODO: fetch controllers from app/javascript/controllers/**/*_controller.js and load/register everything automatically, the filename of the controller will then be used as the controller identifier in the DOM

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,5 +1,5 @@
 <header class="border-b border-gray-200 shadow">
-  <nav class="max-w-7xl mx-auto flex justify-between items-center px-4 lg:px-0">
+  <nav class="max-w-7xl mx-auto flex justify-between items-center px-4">
     <div>
       <%= link_to root_path, class: "block hover:text-primary" do %>
         <div class="flex gap-x-4">

--- a/app/views/time_regs/_date_picker.html.erb
+++ b/app/views/time_regs/_date_picker.html.erb
@@ -3,22 +3,23 @@
     <i class="uc-icon text-gray-600 text-xl">&#xe81f;</i>
   <% end %>
   <div class="w-12 lg:w-40 rounded-md lg:rounded-none">
-    <%= render PhlexUI::Popover.new(options: { trigger: "focusin click" }) do %>
-      <%= render PhlexUI::Popover::Trigger.new(class: "w-full") do %>
-        <div class="py-3 flex justify-center items-center">
-          <span class="hidden lg:block text-sm">
-            <%= @chosen_date.strftime("%d %b %Y") %>
-          </span>
-          <i class="uc-icon text-xl text-gray-600 lg:hidden">&#xe891;</i>
-          <%= form_with url: root_path, method: :get do |form| %>
-            <%= form.hidden_field :date, id: "date_picker_select_cta", value: @chosen_date.strftime("%d %b %Y"), data: { controller: "input" } %>
-            <%# TODO: Fix bug with input not auto submitting form on change, or find a better alternative %>
-            <%#= form.hidden_field :date, id: "date_picker_select_cta", value: @chosen_date.strftime("%d %b %Y"), data: { controller: "custom-calendar" } %>
-          <% end %>
-        </div>
-      <% end %>
-      <%= render PhlexUI::Popover::Content.new do %>
-        <%= render PhlexUI::Calendar.new(selected_date: @chosen_date, input_id: "#date_picker_select_cta") %>
+    <%= form_with url: root_path, method: :get do |form| %>
+      <%= form.hidden_field :date, id: "date_picker_select_cta", value: @chosen_date.strftime("%d %b %Y"), data: { controller: "input" } %>
+      <%= render PhlexUI::Popover.new(options: { trigger: "focusin click" }) do %>
+        <%= render PhlexUI::Popover::Trigger.new(class: "w-full") do %>
+          <div class="py-3 flex justify-center items-center">
+            <span class="hidden lg:block text-sm">
+              <%= @chosen_date.strftime("%d %b %Y") %>
+            </span>
+            <i class="uc-icon text-xl text-gray-600 lg:hidden">&#xe891;</i>
+          </div>
+        <% end %>
+        <%= render PhlexUI::Popover::Content.new do %>
+          <%= render PhlexUI::Calendar.new(selected_date: @chosen_date, input_id: "#date_picker_select_cta") %>
+          <div class="pt-2 border-t border-gray-100">
+            <%= render ButtonComponent.new(type: "submit", class: "w-full", variant: :secondary) { "Update" } %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/time_regs/_main.html.erb
+++ b/app/views/time_regs/_main.html.erb
@@ -1,4 +1,4 @@
-<div class="py-4 lg:py-6 px-4 lg:px-0">
+<div class="py-4 lg:py-6 px-4">
   <div class="max-w-7xl mx-auto flex flex-col gap-y-4">
     <div>
       <span class="text-base lg:text-lg">From <%= @chosen_date.beginning_of_week&.strftime("%B %d, %Y") %> - <%= @chosen_date.end_of_week&.strftime("%B %d, %Y") %></span>

--- a/app/views/time_regs/_top_nav.html.erb
+++ b/app/views/time_regs/_top_nav.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-gray-100 border-b py-4 border-gray-200 px-4 lg:px-0">
+<div class="bg-gray-100 border-b py-4 border-gray-200 px-4">
   <div class="max-w-7xl mx-auto flex justify-between items-center">
     <div class="flex flex-row items-center gap-x-4">
       <div class="bg-white border border-gray-200 rounded flex justify-center items-center px-4 py-3 relative">


### PR DESCRIPTION
### Goal

The goal is to select and view time regs on a specific date

### Current implementation(Phlex UI component)

The datepicker is using [Phlex UI calendar component](https://phlexui.com/docs/calendar) and the way it works is 
`date-picker` [stimulus controller](https://github.com/PhlexUI/phlex_ui_stimulus/blob/main/controllers/calendar_controller.js#L55) will update an `input` [value](https://github.com/PhlexUI/phlex_ui_stimulus/blob/main/controllers/input_controller.js#L6) on date change.


The `date-picker` stimulus controller gets access to the instance of the input stimulus controller by passing the [input identifier](https://github.com/PhlexUI/phlex_ui_pro/blob/main/lib/phlex_ui_pro/calendar.rb#L34) as a [stimulus outlet](https://stimulus.hotwired.dev/reference/outlets).



### Blocker

We're having complexities updating the datetime(send it to backend or query params)  from the existing Phlex calendar, auto submit on date selection requires some over engineering(custom support), I tried to pass the calendar another custom input outlet controller but for some reason it does not execute the functions from this custom implementation


### Solution

Plain and simple, wrap the calendar with a form, it adds an unnecessary click but it works fine and prevent overengineering 

