### PR TITLE
Reducing growing project action items

### DIFF
--- a/app/javascript/controllers/custom_input_controller.js
+++ b/app/javascript/controllers/custom_input_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
 
   handleSubmitButtonValue(inputValue) {
     if(this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.value = (!!inputValue && inputValue !== "0") ? this.activeTextValue : this.inactiveTextValue;
+      this.submitButtonTarget.innerText = (!!inputValue && inputValue !== "0") ? this.activeTextValue : this.inactiveTextValue;
     }
   }
 }

--- a/app/views/time_regs/_form.html.erb
+++ b/app/views/time_regs/_form.html.erb
@@ -11,7 +11,7 @@
             <%= render PhlexUI::Dialog::Description.new { format_date(chosen_date) } %>
           <% end %>
           <%= render PhlexUI::Dialog::Middle.new do %>
-            <%= content_tag(:div, class: "w-full flex flex-col mb-8") do %>
+            <%= content_tag(:div, class: "w-full flex flex-col") do %>
               <div class="block" data-controller="time-tasks">
                 <%= hidden_field_tag :date, chosen_date %>
                 <div class="mb-4" data-time-tasks-target="project">
@@ -62,11 +62,9 @@
               </div>
             <% end %>
           <% end %>
-          <%= render PhlexUI::Dialog::Footer.new(class: "flex flex-row items-center") do %>
-            <%= button_tag type: 'button', data: {action: "click->dismissable#dismiss"}, class: "bg-white shadow p-4 rounded-md flex justify-center items-center" do %>
-              Cancel
-            <% end %>
-            <%= form.submit "", data: { custom_input_target: "submitButton" }, class: "bg-seaGreen shadow text-white hover:bg-seaGreenDark p-4 rounded-md flex justify-center items-center cursor-pointer" %>
+          <%= render PhlexUI::Dialog::Footer.new(class: "mt-4 pt-4 border-t border-gray-100") do %>
+            <%= render ButtonComponent.new(variant: :outline, data: { action: 'click->dismissable#dismiss' }) { "Cancel" } %>
+            <%= render ButtonComponent.new(type: :submit, data: { custom_input_target: "submitButton" }) {} %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/workspace/projects/_project.html.erb
+++ b/app/views/workspace/projects/_project.html.erb
@@ -20,16 +20,34 @@
     </div>
   <% end %>
   <%= render PhlexUI::Table::Cell.new do %>
-    <div class="flex flex-row gap-x-2">
-      <%= render ButtonComponent.new(path: workspace_project_path(project), method: :get, variant: :outline, class: "!py-3") do %>
-        <i class="uc-icon">&#xe9a8;</i>
+    <%= render PhlexUI::Popover.new(options: { placement: "bottom-end", trigger: "click" }) do %>
+      <%= render PhlexUI::Popover::Trigger.new do %>
+        <%= render ButtonComponent.new(variant: :outline) do %>
+          <span class="text-gray-500 text-sm">Actions</span>
+          <i class="uc-icon text-lg text-gray-600 ml-2">&#xe81d;</i>
+        <% end %>
       <% end %>
-      <%= render ButtonComponent.new(path: edit_modal_workspace_project_path(project), method: :put, variant: :outline, class: "!py-3") do %>
-        <i class="uc-icon">&#xe972;</i>
+      <%= render PhlexUI::Popover::Content.new(class: "!p-0") do %>
+        <div class="flex flex-col divide-y divide-gray-50 w-full">
+          <%= render ButtonComponent.new(path: workspace_project_path(project), method: :get, variant: :ghost, class: "!py-3 gap-x-2 !w-full !justify-start hover:bg-gray-100") do %>
+            <i class="uc-icon text-gray-500">&#xe9a8;</i>
+            <%= render PhlexUI::Label.new { "View more"} %>
+          <% end %>
+          <%= render ButtonComponent.new(path: edit_modal_workspace_project_path(project), method: :put, variant: :ghost, class: "!py-3 gap-x-2 !w-full !justify-start hover:bg-gray-100") do %>
+            <i class="uc-icon text-gray-500">&#xe972;</i>
+            <%= render PhlexUI::Label.new { "Edit"} %>
+          <% end %>
+          <%= render ButtonComponent.new(path: delete_confirmation_workspace_project_path(project), method: :post, variant: :ghost, class: "!py-3 gap-x-2 !w-full !justify-start hover:bg-gray-100") do %>
+            <i class="uc-icon text-gray-500">&#xeb97;</i>
+            <%= render PhlexUI::Label.new { "Delete"} %>
+          <% end %>
+        </div>
       <% end %>
-      <%= render ButtonComponent.new(path: delete_confirmation_workspace_project_path(project), method: :post, variant: :outline, class: "!py-3") do %>
-        <i class="uc-icon">&#xeb97;</i>
-      <% end %>
-    </div>
+    <% end %>
+
+
+
+
+
   <% end %>
 <% end %>

--- a/app/views/workspace/projects/show.html.erb
+++ b/app/views/workspace/projects/show.html.erb
@@ -53,7 +53,7 @@
       <% end %>
       <div class="mt-2 py-4 font-medium flex flex-row gap-x-1 justify-end">
         <span>Need to add more members?</span>
-        <%= render ButtonComponent.new(path: new_modal_workspace_project_membership_path(@project), method: :post, variant: :link, class!: "underline text-primary") do %>
+        <%= render ButtonComponent.new(path: new_modal_workspace_project_memberships_path(@project), method: :post, variant: :link, class!: "underline text-primary") do %>
           <span class="mr-2">Add new</span>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
 
       scope module: :projects do
         resources :memberships do
-          post :new_modal, on: :member
+          post :new_modal, on: :collection
           post :delete_confirmation, on: :member
         end
 


### PR DESCRIPTION
This PR is moving the project action items/buttons into a dropdown as it grows.

![Screenshot 2024-04-16 at 09 03 18](https://github.com/rubynor/reap/assets/42216593/031cf3ec-9b97-48f5-b523-c5f602e736fa)
<img width="176" alt="Screenshot 2024-04-16 at 09 00 22" src="https://github.com/rubynor/reap/assets/42216593/39fbfb56-0831-4311-af14-49d187c788dd">
