### PR TITLE
Introducing tasks crud tab

### DIFF
--- a/app/controllers/workspace/tasks_controller.rb
+++ b/app/controllers/workspace/tasks_controller.rb
@@ -45,14 +45,15 @@ module Workspace
     end
 
     def destroy
-      if @task.destroy
+      if @task.assigned_tasks.any?
+        render turbo_stream: turbo_flash(type: :error, data: "Unable to proceed, Task is assigned to a project.")
+      else
+        @task.destroy!
         render turbo_stream: [
           turbo_flash(type: :success, data: "Task was successfully deleted."),
           turbo_stream.remove(dom_id(@task)),
           turbo_stream.action(:remove_modal, :modal)
         ]
-      else
-        render turbo_stream: turbo_flash(type: :error, data: "Unable to proceed, could not delete task.")
       end
     end
 

--- a/app/controllers/workspace/tasks_controller.rb
+++ b/app/controllers/workspace/tasks_controller.rb
@@ -1,0 +1,70 @@
+module Workspace
+  # TODO: This controller has similar actions to the clients controller, consider refactoring
+  # extract duplicated code to a concern
+  class TasksController < WorkspaceController
+    before_action :set_task, only: %i[edit_modal update destroy delete_confirmation]
+
+    def index
+      @tasks = authorized_scope(Task, type: :relation).all
+    end
+
+    def new_modal
+      @task = authorized_scope(Task, type: :relation).new
+    end
+
+    def create
+      @task = authorized_scope(Task, type: :relation).new(task_params)
+
+      if @task.save
+        render turbo_stream: [
+          turbo_flash(type: :success, data: "Task was successfully created."),
+          turbo_stream.append(:organization_tasks, partial: "workspace/tasks/task", locals: { task: @task }),
+          turbo_stream.action(:remove_modal, :modal)
+        ]
+      else
+        render turbo_stream: turbo_stream.replace(:modal, partial: "workspace/tasks/form", locals: { task: @task })
+      end
+    end
+
+    def edit_modal
+    end
+
+    def update
+      if @task.update(task_params)
+        render turbo_stream: [
+          turbo_flash(type: :success, data: "Task was successfully updated."),
+          turbo_stream.replace(dom_id(@task), partial: "workspace/tasks/task", locals: { task: @task }),
+          turbo_stream.action(:remove_modal, :modal)
+        ]
+      else
+        render turbo_stream: turbo_stream.replace(:modal, partial: "workspace/tasks/task", locals: { task: @task })
+      end
+    end
+
+    def delete_confirmation
+    end
+
+    def destroy
+      if @task.destroy
+        render turbo_stream: [
+          turbo_flash(type: :success, data: "Task was successfully deleted."),
+          turbo_stream.remove(dom_id(@task)),
+          turbo_stream.action(:remove_modal, :modal)
+        ]
+      else
+        render turbo_stream: turbo_flash(type: :error, data: "Unable to proceed, could not delete task.")
+      end
+    end
+
+    private
+
+    def task_params
+      params.require(:task).permit(:name)
+    end
+
+    def set_task
+      @task = Task.find(params[:id])
+      authorize! @task
+    end
+  end
+end

--- a/app/policies/workspace/task_policy.rb
+++ b/app/policies/workspace/task_policy.rb
@@ -1,0 +1,11 @@
+module Workspace
+  class TaskPolicy < WorkspacePolicy
+    scope_for :relation do |relation|
+      if user.organization_admin?
+        relation.where(organization: user.current_organization)
+      else
+        relation.none
+      end
+    end
+  end
+end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,7 +5,7 @@
       <div class="hidden lg:flex h-full gap-x-12">
         <%= link_to "Home", time_regs_path, class: class_names("h-full py-6 lg:py-8 transition duration-300 ease-in-out", is_page_active?([root_path, time_regs_path]) ? "text-primary font-semibold border-b-2 border-primary": "hover:text-primary text-gray-600") %>
         <% if current_user.organization_admin? %>
-          <%= link_to "Workspace", workspace_projects_path, class: class_names("h-full py-6 lg:py-8 transition duration-300 ease-in-out", is_page_active?([workspace_projects_path, workspace_clients_path, workspace_teams_path]) ? "text-primary font-semibold border-b-2 border-primary": "hover:text-primary text-gray-600") %>
+          <%= link_to "Workspace", workspace_projects_path, class: class_names("h-full py-6 lg:py-8 transition duration-300 ease-in-out", is_page_active?([workspace_projects_path, workspace_clients_path, workspace_teams_path, workspace_tasks_path]) ? "text-primary font-semibold border-b-2 border-primary": "hover:text-primary text-gray-600") %>
         <% end %>
         <%= link_to "Reports", report_path, class: class_names("h-full py-6 lg:py-8 transition duration-300 ease-in-out", is_page_active?(report_path) ? "text-primary font-semibold border-b-2 border-primary": "hover:text-primary text-gray-600") %>
       </div>

--- a/app/views/workspace/_sidenav.html.erb
+++ b/app/views/workspace/_sidenav.html.erb
@@ -13,6 +13,12 @@
       <% end %>
     </li>
     <li>
+      <%= link_to workspace_tasks_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_tasks_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
+        <i class="uc-icon text-xl">&#xe8f2;</i>
+        <span>Tasks</span>
+      <% end %>
+    </li>
+    <li>
       <%= link_to workspace_teams_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_teams_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
         <i class="uc-icon text-xl">&#xebb3;</i>
         <span>Team members</span>

--- a/app/views/workspace/tasks/_form.html.erb
+++ b/app/views/workspace/tasks/_form.html.erb
@@ -1,0 +1,27 @@
+<%= render PhlexUI::Dialog.new(open: true, data: { controller: "custom-dialog" }) do %>
+  <%= render PhlexUI::Dialog::Trigger.new(class: "hidden", data: { custom_dialog_target: "trigger" }) do %>
+    <%= render PhlexUI::Button.new { "Open Dialog" } %>
+  <% end %>
+  <%= render PhlexUI::Dialog::Content.new(class: "bg-white") do %>
+    <%= turbo_frame_tag :modal do %>
+      <%= form_with url: task.new_record? ? workspace_tasks_path : workspace_task_path, method: task.new_record? ?  :post : :patch, scope: task do |form| %>
+        <div class="flex flex-col gap-y-4">
+          <span class="font-semibold text-gray-600 text-lg"><%= task.new_record? ? "New Task" : "Edit #{task.name}" %></span>
+          <%= content_tag(:div, class: "flex flex-col gap-y-4") do %>
+            <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
+              <%= render PhlexUI::Label.new { "Name" } %>
+              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full" %>
+              <% task.errors.full_messages_for(:name).each do |message|%>
+                <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+        <%= render PhlexUI::Dialog::Footer.new(class: "mt-4 pt-4 border-t border-gray-100") do %>
+          <%= render ButtonComponent.new(variant: :outline, data: { action: 'click->dismissable#dismiss' }) { "Cancel" } %>
+          <%= render ButtonComponent.new(type: :submit) { "Save" } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/workspace/tasks/_task.html.erb
+++ b/app/views/workspace/tasks/_task.html.erb
@@ -1,0 +1,14 @@
+<%= render PhlexUI::Table::Row.new(id: dom_id(task)) do %>
+  <%= render PhlexUI::Table::Cell.new { task.name } %>
+  <%= render PhlexUI::Table::Cell.new { task.created_at.strftime("%A, %d %B %Y") } %>
+  <%= render PhlexUI::Table::Cell.new do %>
+    <div class="flex flex-row gap-x-2">
+      <%= render ButtonComponent.new(path: edit_modal_workspace_task_path(task), method: :post, variant: :outline, class: "!py-3") do %>
+        <i class="uc-icon">&#xe972;</i>
+      <% end %>
+      <%= render ButtonComponent.new(path: delete_confirmation_workspace_task_path(task), method: :post, variant: :outline, class: "!py-3") do %>
+        <i class="uc-icon">&#xeb97;</i>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/workspace/tasks/delete_confirmation.turbo_stream.erb
+++ b/app/views/workspace/tasks/delete_confirmation.turbo_stream.erb
@@ -8,14 +8,20 @@
       <%= render PhlexUI::AlertDialog::Header.new do %>
         <%= render PhlexUI::AlertDialog::Title.new { "Are you sure?" } %>
         <%= render PhlexUI::AlertDialog::Description.new do  %>
-          <span>
-            Do you want to proceed with the deletion of the task <span class="font-semibold text-primary"><%= @task.name %></span>, This action cannot be undone.
-          </span>
+          <% if @task.assigned_tasks.any? %>
+            <span>
+              The task <span class="font-semibold text-primary"><%= @task.name %></span> is already assigned to a project, Kindly remove associated projects if you wish to proceed with this task deletion.
+            </span>
+          <% else %>
+            <span>
+              Do you want to proceed with the deletion of the task <span class="font-semibold text-primary"><%= @task.name %></span>, This action cannot be undone.
+            </span>
+          <% end %>
         <% end %>
       <% end %>
-      <%= render PhlexUI::AlertDialog::Footer.new do %>
+      <%= render PhlexUI::AlertDialog::Footer.new(class: "mt-4") do %>
         <%= render PhlexUI::AlertDialog::Cancel.new(class: "!border-gray-100 !h-12") { "Cancel" } %>
-        <%= render ButtonComponent.new(variant: :destructive, path: workspace_task_path(@task), method: :delete) { "Continue"} %>
+        <%= render ButtonComponent.new(variant: :destructive, path: workspace_task_path(@task), method: :delete, disabled: @task.assigned_tasks.any?) { "Continue"} %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/workspace/tasks/delete_confirmation.turbo_stream.erb
+++ b/app/views/workspace/tasks/delete_confirmation.turbo_stream.erb
@@ -1,0 +1,22 @@
+<%# TODO: Convert into reusable turbo_confirm component that can be triggered with `turbo_confirm` and remove this duplication %>
+<%= render PhlexUI::AlertDialog.new(open: true, data: { controller: "custom-dialog" }) do %>
+  <%= render PhlexUI::AlertDialog::Trigger.new(class: "hidden", data: { custom_dialog_target: "trigger" }) do %>
+    <%= render PhlexUI::Button.new { "Show dialog" } %>
+  <% end %>
+  <%= render PhlexUI::AlertDialog::Content.new do %>
+    <%= turbo_frame_tag :modal do %>
+      <%= render PhlexUI::AlertDialog::Header.new do %>
+        <%= render PhlexUI::AlertDialog::Title.new { "Are you sure?" } %>
+        <%= render PhlexUI::AlertDialog::Description.new do  %>
+          <span>
+            Do you want to proceed with the deletion of the task <span class="font-semibold text-primary"><%= @task.name %></span>, This action cannot be undone.
+          </span>
+        <% end %>
+      <% end %>
+      <%= render PhlexUI::AlertDialog::Footer.new do %>
+        <%= render PhlexUI::AlertDialog::Cancel.new(class: "!border-gray-100 !h-12") { "Cancel" } %>
+        <%= render ButtonComponent.new(variant: :destructive, path: workspace_task_path(@task), method: :delete) { "Continue"} %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/workspace/tasks/edit_modal.turbo_stream.erb
+++ b/app/views/workspace/tasks/edit_modal.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= render partial: "workspace/tasks/form", locals: { task: @task } %>

--- a/app/views/workspace/tasks/index.html.erb
+++ b/app/views/workspace/tasks/index.html.erb
@@ -1,0 +1,30 @@
+<div class="flex flex-col gap-y-8">
+  <div class="flex flex-row justify-between items-center border-b border-gray-100 py-3">
+    <div class="flex flex-row items-center gap-x-2">
+      <span class="font-medium text-gray-600 text-lg">Tasks</span>
+      <div class="bg-gray-100 border border-gray-200 w-6 h-6 flex justify-center items-center rounded-md">
+        <span class="text-gray-700 text-xs font-semibold"><%= @tasks.count %></span>
+      </div>
+    </div>
+    <div class="flex flex-row gap-2">
+      <%= render ButtonComponent.new(path: new_modal_workspace_tasks_path, method: :post) do %>
+        <span class="hidden lg:block mr-2">Add Task</span>
+        <i class="uc-icon text-xl">&#xe9c7;</i>
+      <% end %>
+    </div>
+  </div>
+  <div>
+    <%= render PhlexUI::Table.new do %>
+      <%= render PhlexUI::Table::Header.new do %>
+        <%= render PhlexUI::Table::Row.new do %>
+          <%= render PhlexUI::Table::Head.new { "Name" } %>
+          <%= render PhlexUI::Table::Head.new { "created on" } %>
+          <%= render PhlexUI::Table::Head.new { "Actions" } %>
+        <% end %>
+      <% end %>
+      <%= render PhlexUI::Table::Body.new(id: :organization_tasks) do %>
+        <%= render partial: "workspace/tasks/task", collection: @tasks %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/workspace/tasks/new_modal.turbo_stream.erb
+++ b/app/views/workspace/tasks/new_modal.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= render partial: "workspace/tasks/form", locals: { task: @task } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,5 +88,11 @@ Rails.application.routes.draw do
     resources :teams, only: [ :index, :create ] do
       post :new_modal, on: :collection
     end
+
+    resources :tasks do
+      post :new_modal, on: :collection
+      post :edit_modal, on: :member
+      post :delete_confirmation, on: :member
+    end
   end
 end


### PR DESCRIPTION
### What this PR is adding?

New organization without tasks is currently blocked when creating new Project, this  PR is adding a tasks tab to the workspace to allow them create tasks also from there.

There will be a follow up PR extracting some duplicate controller methods like `clients`, `tasks` into a concern

![Screenshot 2024-04-24 at 10 57 57](https://github.com/rubynor/reap/assets/42216593/8cc23ee1-f429-4cf6-b864-a901de448fa9)

