### PR TITLE
Fix toasts appearing twice

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
 
   # data can either be a hash or a string
   def turbo_flash(type:, data:)
-    flash[type] = data
+    flash.now[type] = data
     turbo_stream.replace "flash", partial: "shared/flash_messages"
   end
 

--- a/app/views/components/snackbar_component.rb
+++ b/app/views/components/snackbar_component.rb
@@ -18,36 +18,34 @@ class SnackbarComponent < ApplicationComponent
   end
 
   def template
-    content_tag(:div, class: "snackbar") do
-      content_tag(:div, **wrapper_options) do
-        content_tag(:div, class: "rounded-lg shadow-sm overflow-hidden") do
-          content_tag(:div, class: "p-4") do
-            content_tag(:div, class: "flex items-start") do
-              content_tag(:div, class: "h-6 w-6") do
-                content_tag(:i, @icon.html_safe, class: @icon_class) if @icon.present?
-              end
-              content_tag(:div, **text_wrapper_options) do
-                content_tag(:div, class: "w-full") do
-                  content_tag(:p, @data[:title], class: "text-sm leading-5 font-medium")
-                  if @data[:body].present?
-                    content_tag(:p, @data[:body], class: "mt-1 text-sm leading-5")
-                  end
-                end
-                content_tag(:div, class: "flex items-center gap-x-6 justify-end") do
-                  if @data[:action].present?
-                    action_btn
-                  end
+    content_tag(:div, **wrapper_options) do
+      content_tag(:div, class: "rounded-lg shadow-sm overflow-hidden") do
+        content_tag(:div, class: "p-4") do
+          content_tag(:div, class: "flex items-start") do
+            content_tag(:div, class: "h-6 w-6") do
+              content_tag(:i, @icon.html_safe, class: @icon_class) if @icon.present?
+            end
+            content_tag(:div, **text_wrapper_options) do
+              content_tag(:div, class: "w-full") do
+                content_tag(:p, @data[:title], class: "text-sm leading-5 font-medium")
+                if @data[:body].present?
+                  content_tag(:p, @data[:body], class: "mt-1 text-sm leading-5")
                 end
               end
-              content_tag(:button, class: "inline-flex focus:outline-none transition ease-in-out duration-150", data: { action: "snackbar#close" }) do
-                content_tag(:i, "&#xeb8e;".html_safe, class: "uc-icon text-gray-600 text-xl")
+              content_tag(:div, class: "flex items-center gap-x-6 justify-end") do
+                if @data[:action].present?
+                  action_btn
+                end
               end
+            end
+            content_tag(:button, class: "inline-flex focus:outline-none transition ease-in-out duration-150", data: { action: "snackbar#close" }) do
+              content_tag(:i, "&#xeb8e;".html_safe, class: "uc-icon text-gray-600 text-xl")
             end
           end
-          if @data[:countdown]
-            content_tag(:div, class: "bg-primary rounded-lg h-1 w-0",  data: { "snackbar-target": "countdown" }) do
-              ""
-            end
+        end
+        if @data[:countdown]
+          content_tag(:div, class: "bg-primary rounded-lg h-1 w-0",  data: { "snackbar-target": "countdown" }) do
+            ""
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
     looking_for: "Can't find what you're looking for?"
     update: "Update"
     project_rate: "Project Rate"
+    new_client: New client
 
   notice:
     are_you_sure: "Are you sure?"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -216,7 +216,7 @@ nb:
     looking_for: "Kan du ikke finne hva du leter etter?"
     update: "Oppdater"
     project_rate: "prosjekt Verdi"
-
+    new_client: Ny klient
 
   notice:
     are_you_sure: "Er du sikker?"


### PR DESCRIPTION
### What this PR is doing

Setting the flash message for the current request only, rather than for the next request. This means that the flash message will be available during the rendering of the current page, but it won't persist to the next request