### PR TITLE
Move projects under tasks

### DIFF
--- a/app/views/workspace/_sidenav.html.erb
+++ b/app/views/workspace/_sidenav.html.erb
@@ -1,12 +1,6 @@
 <div class="px-4">
   <ul class="space-y-1">
     <li>
-      <%= link_to workspace_projects_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_projects_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
-        <i class="uc-icon text-xl">&#xe94f;</i>
-        <span><%= t("common.projects") %></span>
-      <% end %>
-    </li>
-    <li>
       <%= link_to workspace_clients_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_clients_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
         <i class="uc-icon text-xl">&#xe88a;</i>
         <span><%= t("common.client") %></span>
@@ -16,6 +10,12 @@
       <%= link_to workspace_tasks_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_tasks_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
         <i class="uc-icon text-xl">&#xe8f2;</i>
         <span><%= t("common.tasks") %></span>
+      <% end %>
+    </li>
+    <li>
+      <%= link_to workspace_projects_path, class: class_names("group flex items-center gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold", is_page_active?(workspace_projects_path) ? "bg-gray-100 text-primary": "hover:text-primary text-gray-700") do %>
+        <i class="uc-icon text-xl">&#xe94f;</i>
+        <span><%= t("common.projects") %></span>
       <% end %>
     </li>
     <li>


### PR DESCRIPTION
I restructured the way we see the side-navbar
This way the user can go from the top of the navbar, being client and move their way down ending at projects.