### PR TITLE
Remove minimum length for description

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,7 +1,7 @@
 class Client < ApplicationRecord
   validates :name, format: { without: /\r|\n/, message: "Line breaks are not allowed" }
   validates :name, presence: true, length: { minimum: 2, maximum: 30 }, uniqueness: { scope: :organization }
-  validates :description, presence: true, length: { minimum: 2, maximum: 100 }
+  validates :description, length: { maximum: 100 }
 
   has_many :projects
   has_many :time_regs, through: :projects

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,7 @@ class Project < ApplicationRecord
   include RateConvertible
 
   validates :name, presence: true, length: { minimum: 2, maximum: 30 }, uniqueness: { scope: :client }
-  validates :description, presence: true, length: { minimum: 2, maximum: 100 }
+  validates :description, length: { maximum: 100 }
   validates :rate, numericality: { only_integer: true }
 
   belongs_to :client


### PR DESCRIPTION
You are now able to leave description blank and still be able to save.