### PR TITLE
Fix allow adding existing user to organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/193cb743bd02e45896a7/maintainability)](https://codeclimate.com/github/rubynor/reap/maintainability)
 
-[![Test Coverage](https://api.codeclimate.com/v1/badges/193cb743bd02e45896a7/test_coverage)](https://codeclimate.com/github/rubynor/reap/test_coverage)
-
 # Reap time tracking
 Time tracking application written in Ruby on Rails
 ## Getting Started


### PR DESCRIPTION
### What this PR is doing?

This is fixing a bug that was preventing to add an existing user to another organization.


### Note

There was a bug preventing the user to add an existing user to another organization, throughout the fix I noticed that the UI/flow itself should change and not request names and password when we're adding an existing user.

<img width="541" alt="Screenshot 2024-05-22 at 13 57 39" src="https://github.com/rubynor/reap/assets/42216593/8bad8cf2-6194-46f7-9978-67b25d0d04e8">



I'd like to create a follow-up issue/PR that changes this flow a bit

1. Step 1 Provide Email
    a. If user exists then OK(added to organization) 
    b. If user does not exist then display whole form with names and password
