### PR TITLE
Add autofocus on modal forms

### DIFF
--- a/app/javascript/controllers/custom_dialog_controller.js
+++ b/app/javascript/controllers/custom_dialog_controller.js
@@ -1,17 +1,25 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-    static targets = ["trigger"];
+  static targets = ["trigger"];
 
-    connect() {
-     this.showPhlexModal();
-    }
+  connect() {
+    this.showPhlexModal();
+    this.focusOnInput();
+  }
 
-    showPhlexModal() {
-        // let's get all divs that have data-controller="dismissable" and remove them from the DOM
-        const dismissableDivs = document.querySelectorAll('div[data-controller="dismissable"]');
-        dismissableDivs?.forEach((el) => el?.remove());
+  showPhlexModal() {
+    // let's get all divs that have data-controller="dismissable" and remove them from the DOM
+    const dismissableDivs = document.querySelectorAll('div[data-controller="dismissable"]');
+    dismissableDivs?.forEach((el) => el?.remove());
 
-        this.triggerTarget.click();
-    }
+    this.triggerTarget.click();
+  }
+
+  focusOnInput() {
+    const autofocusInput = document.querySelector("[data-state=open] form [autofocus=autofocus]");
+    if (!autofocusInput) return;
+    autofocusInput.focus();
+    autofocusInput.selectionStart = autofocusInput.value.length;
+  }
 }

--- a/app/views/workspace/clients/_form.html.erb
+++ b/app/views/workspace/clients/_form.html.erb
@@ -11,7 +11,7 @@
           <%= content_tag(:div, class: "flex flex-col gap-y-4") do %>
             <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
               <%= render PhlexUI::Label.new { t("common.name") } %>
-              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full" %>
+              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full", autofocus: true %>
               <% client.errors.full_messages_for(:name).each do |message|%>
                 <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
               <% end %>

--- a/app/views/workspace/projects/assigned_tasks/_form.html.erb
+++ b/app/views/workspace/projects/assigned_tasks/_form.html.erb
@@ -38,7 +38,7 @@
               <% else %>
                 <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
                   <%= render PhlexUI::Label.new { "Name" } %>
-                  <%= task_form.text_field :name, class: "border-gray-200 rounded-md" %>
+                  <%= task_form.text_field :name, class: "border-gray-200 rounded-md", autofocus: true %>
                   <% assigned_task.errors.full_messages_for(:name).each do |message|%>
                     <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
                   <% end %>

--- a/app/views/workspace/projects/tasks/_form.html.erb
+++ b/app/views/workspace/projects/tasks/_form.html.erb
@@ -10,7 +10,7 @@
           <%= content_tag(:div, class: "flex flex-col gap-y-4") do %>
             <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
               <%= render PhlexUI::Label.new { "Name" } %>
-              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full" %>
+              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full", autofocus: true %>
               <% task.errors.full_messages.each do |message|%>
                 <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
               <% end %>

--- a/app/views/workspace/tasks/_form.html.erb
+++ b/app/views/workspace/tasks/_form.html.erb
@@ -10,7 +10,7 @@
           <%= content_tag(:div, class: "flex flex-col gap-y-4") do %>
             <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
               <%= render PhlexUI::Label.new { t("common.name") } %>
-              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full" %>
+              <%= form.text_field :name, class: "border-gray-200 rounded-md w-full", autofocus: true %>
               <% task.errors.full_messages_for(:name).each do |message|%>
                 <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
               <% end %>

--- a/app/views/workspace/teams/_form.html.erb
+++ b/app/views/workspace/teams/_form.html.erb
@@ -10,7 +10,7 @@
           <%= content_tag(:div, class: "flex flex-col gap-y-4") do %>
             <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
               <%= render PhlexUI::Label.new { t("registration.first_name") } %>
-              <%= form.text_field :first_name, required: true, class: "border-gray-200 rounded-md w-full" %>
+              <%= form.text_field :first_name, required: true, class: "border-gray-200 rounded-md w-full", autofocus: true %>
               <% user.errors.full_messages_for(:first_name).each do |message|%>
                 <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
               <% end %>


### PR DESCRIPTION
## What this PR is adding
* `autofocus` attribute to the first input fields in forms used in modals.
* A auto focus feature in stimulus to preserve the focus state, as the input fields gets blurred when closing a modal.