### PR TITLE
Allow time input to be decimal number

### DIFF
--- a/app/javascript/controllers/custom_input_controller.js
+++ b/app/javascript/controllers/custom_input_controller.js
@@ -14,9 +14,25 @@ export default class extends Controller {
   }
 
   cloneValue(e) {
-    const eventTargetValue = e.target.value;
-    this.cloneTarget.value = this.stringToTime(eventTargetValue);
-    this.handleSubmitButtonValue(eventTargetValue);
+    e.target.value = this.decimalToTimestamp(e.target.value);
+
+    this.cloneTarget.value = this.stringToTime(e.target.value);
+
+    this.handleSubmitButtonValue(e.target.value);
+  }
+
+  decimalToTimestamp(decimalString) {
+    if (decimalString.includes(':')) return decimalString;
+
+    const contentString = decimalString.replace(',', '.');
+    const decimal = parseFloat(contentString);
+
+    const hours = Math.floor(decimal);
+    let minutes = Math.round((decimal - hours) * 60);
+
+    if (minutes < 10) minutes = '0' + minutes;
+
+    return `${hours}:${minutes}`;
   }
 
   stringToTime(inputString) {
@@ -29,7 +45,7 @@ export default class extends Controller {
   }
 
   handleSubmitButtonValue(inputValue) {
-    if(this.hasSubmitButtonTarget) {
+    if (this.hasSubmitButtonTarget) {
       this.submitButtonTarget.innerText = (!!inputValue && inputValue !== "0") ? this.activeTextValue : this.inactiveTextValue;
     }
   }

--- a/app/views/time_regs/_form.html.erb
+++ b/app/views/time_regs/_form.html.erb
@@ -62,7 +62,7 @@
                 <% end %>
                 <%= form.hidden_field :minutes, data: { "custom-input-target": "clone" } %>
                 <%= form.text_field :minutes_string, placeholder: "0:00", autocomplete: "off", data: {
-                  action: "custom-input#cloneValue"
+                  action: "change->custom-input#cloneValue"
                 }, value: (convert_time_int(time_reg.minutes) unless time_reg.new_record?),
                                     class: 'text-end w-full rounded-md p-2 border border-gray-300 focus:ring-1 focus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white'
                 %>


### PR DESCRIPTION
## What this PR is adding
Ability to enter time as a decimal number, with either `.` or `,`.

## Screenshots

![image](https://github.com/rubynor/reap/assets/29040689/35563008-bb1a-4f98-b365-1dea5a663e06)