### PR TITLE
Wrapped ButtonComponent objects with link_to helper when GET-method

### DIFF
--- a/app/views/components/button_component.rb
+++ b/app/views/components/button_component.rb
@@ -9,7 +9,11 @@ class ButtonComponent < ApplicationComponent
 
   def template(&content)
     if @path.present?
-      button_to(@path, method: @method, **@attrs) { render_button(&content) }
+      if @method == :get
+        link_to(@path, **@attrs) { render_button(&content) }
+      else
+        button_to(@path, method: @method, **@attrs) { render_button(&content) }
+      end
     else
       render_button(&content)
     end


### PR DESCRIPTION
Wrapped the ButtonComponents with link_to when using GET-method, in order to allow pre-loading of the page when hovering the link. button_to does not support this. ButtonComponent is rarely used with GET-method, but when it is, we want it to function like a link. It still looks the same.