### PR TITLE
Fix select component going off-screen

### DIFF
--- a/app/views/components/application_component.rb
+++ b/app/views/components/application_component.rb
@@ -9,10 +9,25 @@ class ApplicationComponent < Phlex::HTML
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::LinkTo
 
+  def initialize(**user_attrs)
+    @attrs = default_attrs.merge(user_attrs)
+    @attrs[:class] = tokens(default_classes, user_attrs[:class])
+  end
+
   if Rails.env.development?
     def before_template
       comment { "Before #{self.class.name}" }
       super
     end
+  end
+
+  private
+
+  def default_attrs
+    {}
+  end
+
+  def default_classes
+    ""
   end
 end

--- a/app/views/components/dropdown_component.rb
+++ b/app/views/components/dropdown_component.rb
@@ -1,7 +1,7 @@
 class DropdownComponent < ApplicationComponent
   def initialize(options: {}, **attrs)
     @close_background_delay = options.fetch(:close_background_delay, false)
-    @attrs = attrs.merge(default_attrs)
+    super(**attrs)
   end
 
   def template(&block)
@@ -16,15 +16,18 @@ class DropdownComponent < ApplicationComponent
         controller: "custom-dropdown",
         action: "keyup@window->custom-dropdown#closeWithKeyboard click@window->custom-dropdown#closeBackground",
         custom_dropdown_close_background_delay_value: @close_background_delay
-      },
-      class: "relative custom-dropdown-component cursor-pointer"
+      }
     }
+  end
+
+  def default_classes
+    "relative custom-dropdown-component cursor-pointer"
   end
 end
 
 class DropdownComponent::Trigger < ApplicationComponent
   def initialize(**attrs)
-    @attrs = attrs.merge(default_attrs)
+    super(**attrs)
   end
 
   def template(&block)
@@ -45,7 +48,7 @@ end
 
 class DropdownComponent::Content < ApplicationComponent
   def initialize(**attrs)
-    @attrs = attrs.merge(default_attrs)
+    super(**attrs)
   end
 
   def template(&block)
@@ -58,8 +61,11 @@ class DropdownComponent::Content < ApplicationComponent
     {
       data: {
         custom_dropdown_target: "content"
-      },
-      class: "z-50 rounded-md border bg-background p-2 text-foreground shadow-md outline-none mt-2 hidden left-0 custom-dropdown-component-content cursor-defaut"
+      }
     }
+  end
+
+  def default_classes
+    "z-50 rounded-md border bg-background p-2 text-foreground shadow-md outline-none mt-2 hidden left-0 custom-dropdown-component-content cursor-defaut"
   end
 end

--- a/app/views/workspace/projects/_form.html.erb
+++ b/app/views/workspace/projects/_form.html.erb
@@ -11,7 +11,7 @@
           <%= content_tag(:div, class: "flex flex-col gap-y-4", data: { controller: "custom-disable", custom_disable_initial_status_value: project.billable }) do %>
             <%= render PhlexUI::Form::Item.new do  %>
               <%= render PhlexUI::Label.new { t("common.client") } %>
-              <%= render PhlexUI::Select::Builder.new(project, "client_id", collection: clients.map { |client| [client.name, client.id] }, placeholder: t("common.select_client"), trigger_attrs: { class: "!border-gray-200" }) %>
+              <%= render PhlexUI::Select::Builder.new(project, "client_id", collection: clients.map { |client| [client.name, client.id] }, placeholder: t("common.select_client"), trigger_attrs: { class: "!border-gray-200" }, content_attrs: { class: "max-h-[20rem] overflow-y-scroll" }) %>
               <% project.errors.full_messages_for(:client).each do |message|%>
                 <%= render PhlexUI::InputError.new(class: "w-full text-red-600 italic text-xs") { message }  %>
               <% end %>

--- a/app/views/workspace/projects/_form.html.erb
+++ b/app/views/workspace/projects/_form.html.erb
@@ -72,7 +72,7 @@
                   <span class="text-gray-500 text-sm"><%= t("common.select_tasks") %></span>
                   <i class="uc-icon text-lg text-gray-600 ml-2">&#xe81d;</i>
                 <% end %>
-                <%= render DropdownComponent::Content.new(class: "w-full !p-4") do %>
+                <%= render DropdownComponent::Content.new(class: "w-full max-h-[20rem] !p-5 overflow-y-scroll") do %>
                   <div class="flex flex-col text-sm w-full gap-y-4">
                     <%= form.collection_check_boxes :task_ids, @tasks, :id, :name do |task| %>
                       <div class="flex items-center space-x-2">


### PR DESCRIPTION
## What this PR is adding
* Update to `ApplicationComponent` for merging css styles.
* Max height and overflow style to select components in the "New/Edit project" form.

### Underlying issue
It was not possible to add additional classes when using a custom component, due to the use of `merge`, overwriting `:class` with the default classes from the component.

## Screenshots
![image](https://github.com/rubynor/reap/assets/29040689/396a1341-2144-4037-ac18-d24677447cdc)
