### PR TITLE
Fixed join naming error in TimeRegPolicy

### DIFF
--- a/app/policies/time_reg_policy.rb
+++ b/app/policies/time_reg_policy.rb
@@ -22,7 +22,7 @@ class TimeRegPolicy < ApplicationPolicy
     if user.organization_admin?
       relation.joins(:organization).where(organizations: organization).distinct
     else
-      relation.joins(:organization, :users).where(organizations: organization, users: user).distinct
+      relation.joins(:organization, :user).where(organizations: organization, users: user).distinct
     end
   end
 


### PR DESCRIPTION
This caused an internal server error because it couldn't find the table it wanted to join with.