### PR TITLE
Fix broken TimeReg input field

### DIFF
--- a/app/javascript/controllers/custom_input_controller.js
+++ b/app/javascript/controllers/custom_input_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="input"
 export default class extends Controller {
-  static targets = ["clone", "submitButton"];
+  static targets = ["trigger", "clone", "submitButton"];
 
   static values = {
     activeText: { type: String, default: '' },
@@ -13,15 +13,18 @@ export default class extends Controller {
     this.handleSubmitButtonValue(this.cloneTarget.value);
   }
 
-  cloneValue(e) {
-    e.target.value = this.decimalToTimestamp(e.target.value);
+  updateFormat() {
+    this.triggerTarget.value = this.decimalToTimestamp(this.triggerTarget.value);
+    this.updateClone();
+  }
 
-    this.cloneTarget.value = this.stringToTime(e.target.value);
-
-    this.handleSubmitButtonValue(e.target.value);
+  updateClone() {
+    this.cloneTarget.value = this.stringToTime(this.triggerTarget.value);
+    this.handleSubmitButtonValue(this.cloneTarget.value);
   }
 
   decimalToTimestamp(decimalString) {
+    if (decimalString.trim() === "") return "";
     if (decimalString.includes(':')) return decimalString;
 
     const contentString = decimalString.replace(',', '.');
@@ -37,6 +40,7 @@ export default class extends Controller {
 
   stringToTime(inputString) {
     // Only allow numbers and colon
+    if (inputString.trim() === "") return 0;
     if (!/^[0-9:]+$/.test(inputString)) return NaN;
 
     const [hours, minutes] = inputString.split(":").map(str => parseInt(str) || 0);

--- a/app/views/time_regs/_form.html.erb
+++ b/app/views/time_regs/_form.html.erb
@@ -62,7 +62,8 @@
                 <% end %>
                 <%= form.hidden_field :minutes, data: { "custom-input-target": "clone" } %>
                 <%= form.text_field :minutes_string, placeholder: "0:00", autocomplete: "off", data: {
-                  action: "change->custom-input#cloneValue"
+                  action: "custom-input#updateClone change->custom-input#updateFormat",
+                  "custom-input-target": "trigger"
                 }, value: (convert_time_int(time_reg.minutes) unless time_reg.new_record?),
                                     class: 'text-end w-full rounded-md p-2 border border-gray-300 focus:ring-1 focus:ring-seaGreenDark focus:border-seaGreenDark ring-offset-1 ring-offset-white'
                 %>


### PR DESCRIPTION
## What this PR is adding
Fixes to `custom_input_controller`. 
The controller will now update the clone value on `input` event, and update the input format on `change` event.
+
The controller will now leave the input value empty, instead of setting it to `NaN:NaN`.