### PR TITLE
Chore - migration removing old column name on assigned_task

### DIFF
--- a/db/migrate/20240621074112_remove_name_from_assigned_tasks.rb
+++ b/db/migrate/20240621074112_remove_name_from_assigned_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromAssignedTasks < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :assigned_tasks, :name }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_26_062759) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_21_074112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_062759) do
     t.bigint "task_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
     t.integer "rate", default: 0, null: false
     t.boolean "is_archived", default: false
     t.index ["project_id"], name: "index_assigned_tasks_on_project_id"


### PR DESCRIPTION
This is just a cleanup removing an old unused column