### PR TITLE
Fixed policy error causing it to be impossible to create new project

### DIFF
--- a/app/controllers/workspace/projects_controller.rb
+++ b/app/controllers/workspace/projects_controller.rb
@@ -51,7 +51,7 @@ module Workspace
 
     def new_modal
       @project = authorized_scope(Project, type: :relation).new
-      authorize! @project
+      authorize!
     end
 
     def import_modal

--- a/app/policies/workspace/project_policy.rb
+++ b/app/policies/workspace/project_policy.rb
@@ -1,10 +1,10 @@
 module Workspace
   class ProjectPolicy < WorkspacePolicy
-    %i[ index import_modal ].each do |action|
+    %i[ index import_modal new_modal ].each do |action|
       define_method("#{action}?") { user.organization_admin? }
     end
 
-    %i[ create show edit_modal update new_modal destroy add_member_modal ].each do |action|
+    %i[ create show edit_modal update destroy add_member_modal ].each do |action|
       define_method("#{action}?") do
         user.organization_admin? && record.organization == user.current_organization
       end


### PR DESCRIPTION
Reason: There was a mistake in /app/policies/workspace/project_policy.rb where the new_modal policy didn't work because record.organization is not defined for new records. This fixes it by just checking if the user is an admin when opening a new_modal.