### PR TITLE
Small UI improvements

### DIFF
--- a/app/views/organizations/_switch.html.erb
+++ b/app/views/organizations/_switch.html.erb
@@ -17,10 +17,10 @@
       <%= render PhlexUI::Dialog::Title.new { t("common.organizations") } %>
     <% end %>
     <%= render PhlexUI::Dialog::Middle.new do %>
-      <%= content_tag(:div, class: "flex flex-col overflow-y-scroll max-h-[600px]") do %>
+      <%= content_tag(:div, class: "flex flex-col overflow-y-auto max-h-[600px]") do %>
         <% user.organizations.order(name: :asc).each do |organization| %>
           <div class="relative">
-            <%= button_to set_current_organization_path(organization.id), method: :post, data: { turbo: false }, class: class_names("pointer-events-auto flex flex-col items-center lg:items-start p-2 md:p-4 lg:p-6 transition duration-300 ease-in-out",  "bg-gradient-to-r from-pink-50 lg:from-pink-100": organization == user.current_organization) do %>
+            <%= button_to set_current_organization_path(organization.id), method: :post, data: { turbo: false }, class: class_names("w-full pointer-events-auto flex flex-col items-center lg:items-start p-2 md:p-4 lg:p-6 transition duration-300 ease-in-out",  "bg-gradient-to-r from-pink-50 lg:from-pink-100": organization == user.current_organization) do %>
               <%= content_tag(:span, organization.name, class: class_names("text-base md:text-xl lg:text-xl font-regular text-gray-400 transition duration-300 ease-in-out", "text-gray-600 font-semibold": organization == user.current_organization) ) %>
             <% end %>
             <% if organization == user.current_organization %>

--- a/app/views/reports/details/_extended.html.erb
+++ b/app/views/reports/details/_extended.html.erb
@@ -62,7 +62,7 @@
                 <div class="flex flex-col gap-3">
                   <div class="flex flex-col">
                     <span><%= child.task.name %></span>
-                    <span class="text-gray-500 text-sm print:text-xs"><%= child.notes %></span>
+                    <%= simple_format child.notes, wrapper_tag: "span", class: "text-gray-500 text-sm print:text-xs" %>
                   </div>
                 </div>
               </td>

--- a/app/views/time_regs/_time_reg.html.erb
+++ b/app/views/time_regs/_time_reg.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
     <div class="flex flex-row items-start w-full gap-x-2">
-      <div class="flex flex-col w-auto">
+      <div class="flex flex-col w-full lg:w-auto">
         <div class="flex flex-row gap-x-2 justify-between lg:justify-start">
           <div class="flex flex-col lg:flex-row lg:items-center text-sm lg:text-base text-gray-600 gap-x-2 w-fit">
             <span><%= time_reg.task.name %></span>
@@ -28,8 +28,8 @@
         <div class="w-fit">
           <span class="text-sm text-gray-800"><%= time_reg.project.client.name %></span>
         </div>
-        <div class="w-full md:w-3/4 lg:w-1/2">
-          <p class="text-xs text-gray-500"><%= time_reg.notes %></p>
+        <div class="w-full lg:pr-6">
+          <%= simple_format time_reg.notes, class: "text-xs text-gray-500" %>
         </div>
       </div>
     </div>
@@ -41,12 +41,12 @@
     <% else %>
       <i class="uc-icon text-base">&#xead1;</i>
     <% end %>
-    <span class="hidden lg:block"><%= time_reg.active? ? t("common.stop") : t("common.start") %></span>
+    <span class="hidden md:block"><%= time_reg.active? ? t("common.stop") : t("common.start") %></span>
   <% end %>
 
     <%= render ButtonComponent.new(path: edit_modal_time_reg_path(time_reg, date: @chosen_date), method: :put, class: "gap-x-2", variant: :outline) do %>
       <i class="uc-icon text-base">&#xe972;</i>
-      <span class="hidden lg:block"><%= t("common.edit") %></span>
+      <span class="hidden md:block"><%= t("common.edit") %></span>
     <% end %>
 
     <%- turbo_body = "
@@ -61,7 +61,7 @@
 
     <%= render ButtonComponent.new(variant: :destructive, method: :delete, path: time_reg_path(time_reg), form: { data: { turbo_confirm: turbo_body } }) do %>
       <i class="uc-icon text-base">&#xeb97;</i>
-      <span class="hidden lg:block"><%= t("common.delete") %></span>
+      <span class="hidden md:block"><%= t("common.delete") %></span>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
- Rendering newlines from time_reg notes. This is handy if you f.ex. note what you do in bullet points. Also the notes section isn't unnecessarily narrow anymore.
- Organization switcher improvements: button width fills whole modal and scroll-bar only shows when necessary.