### PR TITLE
Bugfix: navigating pages before logging in, resets language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,9 +31,9 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name locale])
     devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name])
-    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name])
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name locale])
   end
 
   # data can either be a hash or a string
@@ -43,13 +43,14 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    locale = params[:locale] || locale_from_current_user || extract_locale_from_accept_language_header || I18n.default_locale
+    locale = params[:locale] || locale_from_current_user || session[:locale]  || extract_locale_from_accept_language_header || I18n.default_locale
 
     begin
       I18n.locale = locale
     rescue I18n::InvalidLocale
       I18n.locale = I18n.default_locale
     end
+    session[:locale] = I18n.locale
   end
 
   def locale_from_current_user

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,7 @@
       <%= render AlertComponent.new(variant: :destructive, title: "Unable to proceed!", message: resource.errors.full_messages) if resource.errors.any? %>
       <div class="w-full flex gap-y-4 flex-col mt-4">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+        <%= form.hidden_field :locale, value: I18n.locale %>
         <div class="flex flex-col w-full gap-y-4 lg:gap-y-8 mb-4">
           <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do  %>
             <%= render PhlexUI::Label.new { t("registration.first_name") } %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -27,7 +27,7 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 h-screen">
         <div class="bg-gray-50 h-full relative">
           <div class="absolute top-0 left-0 w-full">
-            <div class="flex w-full justify-between max-w-xl mx-auto px-4 py-6 lg:py-10">
+            <div class="flex items-center w-full justify-between max-w-xl mx-auto px-4 py-6 lg:py-10">
               <%= link_to root_path, class: "text-2xl flex items-center gap-x-2" do %>
                 <%= show_svg("logo.svg") %>
                 <h1 class="ml-4 text-xl text-gray-900 font-semibold">Stemplin</h1>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -5,6 +5,7 @@
   <div class="flex flex-col mt-4 gap-y-2">
     <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
       <%= f.hidden_field :invitation_token, readonly: true %>
+      <%= f.hidden_field :locale, value: I18n.locale %>
 
       <div class="w-full flex flex-col gap-y-4 lg:gap-y-8">
         <%= render PhlexUI::Form::Item.new(class: "flex flex-col") do %>

--- a/config/locales/devise.nb.yml
+++ b/config/locales/devise.nb.yml
@@ -47,6 +47,8 @@ nb:
       send_instructions: "Du vil innen få minutter motta en epost med instruksjoner for å gjenåpne din konto."
       send_paranoid_instructions: "Hvis kontoen din eksisterer vil du innen få minutter motta en epost med instruksjoner for å låse den opp."
       unlocked: "Din konto er gjenåpnet. Vennligst logg inn for å fortsette."
+    invitations:
+      updated: "Profil ble oppdatert. Du er nå logget inn."
   errors:
     messages:
       already_confirmed: "har allerede blitt bekreftet, forsøk å logg inn"


### PR DESCRIPTION
- Submitting an invalid form, refreshing the page, or navigating to anohter page before logging in, used to reset the language to English. Solved this by storing the language in the session (should be fine since it doesn't take much memory).
- Also, the current language is now automatically saved to the user when a new user signs up.
- Added missing translation when accepting invitation