### PR TITLE
Fix front end timer not in sync with back end

### DIFF
--- a/app/javascript/controllers/refresh_minutes_controller.js
+++ b/app/javascript/controllers/refresh_minutes_controller.js
@@ -4,6 +4,8 @@ import momentDurationFormatSetup from "moment-duration-format";
 
 momentDurationFormatSetup(moment); // Setup moment-duration-format plugin
 
+const MINUTE = 1000 * 60;
+
 // Connects to data-controller="refresh-minutes"
 export default class extends Controller {
   static targets = ['minutes'];
@@ -37,7 +39,7 @@ export default class extends Controller {
   toggleRefresh() {
     this.clearCurrentTimeout();
     if (this.activeValue && !this.timeoutId) {
-      this.interval = 1000;
+      this.interval = MINUTE;
       this.expected = Date.now() + this.interval;
       this.now = Date.now();
 


### PR DESCRIPTION
## What this PR is changing
Changing the way we time updates for the `time_reg` time stamp.

### The old solution
Previously we used a `setInterval()` function to update time stamp one second apart.
The problem with this solution is that is not exactly accurate. There will be a small amount of drifting time for every iteration, so when the timer runs for a long time, the calculated time will not be the same as on the server.
(The time drift will also get worse when the tab is inactive, as browsers try to reduce processes in background tabs, including timers: https://blog.chromium.org/2020/11/tab-throttling-and-more-performance.html)

### The new solution
This PR introduces a "self adjusting timer", that calculates the drifting time, and takes it into account.
The `setInterval()` function in not used here, but the `setTimeout()` function instead, so we are able to adjust the interval as the time drift changes.

https://stackoverflow.com/questions/29971898/how-to-create-an-accurate-timer-in-javascript

## Screenshots
![image](https://github.com/user-attachments/assets/81fa9b17-8aa6-44d6-82ad-07f305efbcbe)
