### PR TITLE
Small design tweaks

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,7 +2,7 @@ class Client < ApplicationRecord
   include Deletable
 
   validates :name, format: { without: /\r|\n/, message: "Line breaks are not allowed" }
-  validates :name, presence: true, length: { minimum: 2, maximum: 30 }, uniqueness: { scope: :organization }
+  validates :name, presence: true, length: { minimum: 2, maximum: 60 }, uniqueness: { scope: :organization }
   validates :description, length: { maximum: 100 }
 
   has_many :projects

--- a/app/views/workspace/projects/_project.html.erb
+++ b/app/views/workspace/projects/_project.html.erb
@@ -4,7 +4,7 @@
       <div class="flex flex-row items-center gap-x-1">
         <span class="font-medium text-gray-700 text-sm"><%= project.name %></span>
       </div>
-      <div class="w-32 sm:w-64 lg:w-80 xl:w-96 truncate">
+      <div class="w-32 sm:w-64 lg:w-80 xl:w-96">
         <span class="text-gray-500 text-xs"><%= project.description %></span>
       </div>
     <% end %>

--- a/app/views/workspace/projects/show.html.erb
+++ b/app/views/workspace/projects/show.html.erb
@@ -9,7 +9,7 @@
           <span><%= @project.name %></span>
           <%= render PhlexUI::Badge.new(variant: :purple, class: "!rounded-full flex gap-x-1") { t("common.project") } %>
         </div>
-        <span class="text-gray-500 text-sm font-regular"><%= @project.description %></span>
+        <span class="text-gray-500 text-sm font-regular pr-2"><%= @project.description %></span>
       </div>
     </div>
     <div class="flex flex-row gap-2">


### PR DESCRIPTION
To accommodate larger client names, and avoid truncating the description.