### PR TITLE
Remove test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,13 +40,8 @@ jobs:
         run: bin/rake assets:precompile
       - name: Set up database schema
         run: bin/rails db:schema:load
-      - name: Run tests and Push test coverage to Code Climate
-        uses: paambaati/codeclimate-action@v6.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageCommand: bin/rake test
-          debug: true
+      - name: Run tests
+        run: bin/rails test
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,4 @@
 .env
 
 .DS_Store
-coverage
 /dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
   gem "rails-controller-testing"
-  gem "simplecov"
 end
 
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
       devise (>= 4.6)
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
-    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -337,12 +336,6 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 6, < 8)
       tilt (>= 1.4.0, < 3)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
     sin_lru_redux (2.5.2)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
@@ -427,7 +420,6 @@ DEPENDENCIES
   sentry-ruby
   sidekiq (~> 7.3)
   sidekiq-scheduler
-  simplecov
   sprockets-rails
   stimulus-rails
   strong_migrations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,3 @@
-require "simplecov"
-SimpleCov.start "rails" do
-  add_filter "/bin/"
-  add_filter "/db/"
-  add_filter "/test/"
-  add_filter "/config/"
-  add_filter "/app/javascript/"
-  add_filter "/app/views/components/"
-
-  # Groups not covered by default
-  add_group "Policies", "app/policies"
-  add_group "Presenters", "app/presenters"
-  add_group "Services", "app/services"
-  add_group "Components", "app/views/components"
-end
-
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
@@ -25,9 +9,7 @@ Sidekiq::Testing.fake!
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-
-  # Parallel tests disabled. Can be enables, but requires some configuration with simplecov
-  # parallelize(workers: :number_of_processors)
+  parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
@@ -37,8 +19,7 @@ end
 
 
 class ActionController::TestCase
-  # Parallel tests disabled. Can be enables, but requires some configuration with simplecov
-  # parallelize(workers: :number_of_processors)
+  parallelize(workers: :number_of_processors)
   fixtures :all
   include Devise::Test::ControllerHelpers
   include ActionPolicy::TestHelper


### PR DESCRIPTION
**Description**
This PR removes the use of simplecov

**Changes Made**
List the major changes introduced by this PR:
1. Removed the Github action
2. Removed the `simplecov` gem and the user of it
3. Enabled parallel testing as before
