### PR TITLE
Make trufflehog ignore postgres host

### DIFF
--- a/.trufflehogignore
+++ b/.trufflehogignore
@@ -1,0 +1,5 @@
+# TruffleHog ignore patterns
+# These are development-only Docker Compose credentials, not production secrets
+
+# Docker Compose PostgreSQL development credentials
+docker-compose.yml:postgres://postgres:postgres@db:5432


### PR DESCRIPTION
**Description**
This PR adds a `.trufflehogignore` file to disable secret scanning for docker-compose postgres URLs

**Changes Made**
List the major changes introduced by this PR:
1. Added `.trufflehogignore` file and ignored `docker-compose.yml:postgres://postgres:postgres@db:5432`
