### PR TITLE
Add missing `</option>` closing tag

### DIFF
--- a/app/views/workspace/projects/assigned_tasks/_form.html.erb
+++ b/app/views/workspace/projects/assigned_tasks/_form.html.erb
@@ -19,7 +19,7 @@
                 <%= task_form.text_field :name, class: "border-gray-200 rounded-md w-full", autofocus: true, autocomplete: "off", list: "unassigned-tasks-list" %>
                 <datalist id="unassigned-tasks-list">
                   <% unassigned_tasks.each do |task| %>
-                    <option value="<%= task.name %>">
+                    <option value="<%= task.name %>"></option>
                   <% end %>
                 </datalist>
               <% end %>


### PR DESCRIPTION
**Description**

This pull request adds a missing `</option>` closing tag, found using the [`herb analyze`](https://github.com/marcoroth/herb) CLI.

**Related Issue**

\-

**Changes Made**

* Add missing `</option>` closing tag

**How to Test**
\-


**Screenshots (if applicable)**

\-

**Additional Context**
\-

